### PR TITLE
add: non_random_access in decompress; double data running example in …

### DIFF
--- a/SZp/include/szp.h
+++ b/SZp/include/szp.h
@@ -30,8 +30,8 @@
 extern "C" {
 #endif
 
-unsigned char *szp_compress(int fastMode, int dataType, void *data, size_t *outSize, int errBoundMode, float absErrBound,
-                                      float relBoundRatio, size_t nbEle, int blockSize);
+unsigned char *szp_compress(int fastMode, int dataType, void *data, size_t *outSize, int errBoundMode, double absErrBound,
+                                      double relBoundRatio, size_t nbEle, int blockSize);
                                       
 void* szp_decompress(int fastMode, int dataType, unsigned char *bytes, size_t byteLength, size_t nbEle, int blockSize);
 

--- a/SZp/include/szp_double.h
+++ b/SZp/include/szp_double.h
@@ -40,7 +40,7 @@ size_t szp_double_single_thread_arg_record(unsigned char *output, double *oriDat
                                        size_t nbEle, int blockSize);
 
 void
-szp_double_openmp_threadblock_randomaccess_args(unsigned char* output, double *oriData, size_t *outSize, double absErrBound,
+szp_double_openmp_threadblock_randomaccess_arg(unsigned char* output, double *oriData, size_t *outSize, double absErrBound,
                                           size_t nbEle, int blockSize);
 
 #ifdef __cplusplus

--- a/SZp/include/szp_float.h
+++ b/SZp/include/szp_float.h
@@ -40,7 +40,7 @@ size_t szp_float_single_thread_arg_record(unsigned char *output, float *oriData,
                                        size_t nbEle, int blockSize);
 
 void
-szp_float_openmp_threadblock_randomaccess_args(unsigned char *output, float *oriData, size_t *outSize, float absErrBound,
+szp_float_openmp_threadblock_randomaccess_arg(unsigned char *output, float *oriData, size_t *outSize, float absErrBound,
                                           size_t nbEle, int blockSize);
 
 #ifdef __cplusplus

--- a/SZp/include/szpd_double.h
+++ b/SZp/include/szpd_double.h
@@ -26,7 +26,7 @@ void szp_double_decompress_single_thread_arg(double *newData, size_t nbEle, doub
 
 size_t szp_double_decompress_single_thread_arg_record(double *newData, size_t nbEle, double absErrBound, int blockSize, unsigned char *cmpBytes);
 
-void szp_double_decompress_openmp_threadblock_randomaccess_args(double **newData, size_t nbEle, double absErrBound, int blockSize, unsigned char *cmpBytes);
+void szp_double_decompress_openmp_threadblock_randomaccess_arg(double *newData, size_t nbEle, double absErrBound, int blockSize, unsigned char *cmpBytes);
 
 #ifdef __cplusplus
 }

--- a/SZp/include/szpd_float.h
+++ b/SZp/include/szpd_float.h
@@ -26,7 +26,7 @@ void szp_float_decompress_single_thread_arg(float *newData, size_t nbEle, float 
 
 size_t szp_float_decompress_single_thread_arg_record(float *newData, size_t nbEle, float absErrBound, int blockSize, unsigned char *cmpBytes);
 
-void szp_float_decompress_openmp_threadblock_randomaccess_args(float **newData, size_t nbEle, float absErrBound, int blockSize, unsigned char *cmpBytes);
+void szp_float_decompress_openmp_threadblock_randomaccess_arg(float *newData, size_t nbEle, float absErrBound, int blockSize, unsigned char *cmpBytes);
 
 #ifdef __cplusplus
 }

--- a/SZp/src/szp.cc
+++ b/SZp/src/szp.cc
@@ -1,12 +1,11 @@
 /**
- *  @file szp.cc
- *  @author Sheng Di
- *  @date Jan, 2022
- *  @brief 
- *  (C) 2022 by Mathematics and Computer Science (MCS), Argonne National Laboratory.
- *      See COPYRIGHT in top-level directory.
- */
-
+ *  @file szp.cc
+ *  @author Sheng Di
+ *  @date Jan, 2022
+ *  @brief
+ *  (C) 2022 by Mathematics and Computer Science (MCS), Argonne National Laboratory.
+ *    See COPYRIGHT in top-level directory.
+ */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,23 +14,23 @@
 #include "szp.h"
 #include "szp_rw.h"
 
-int szp_versionNumber[4] = {szp_VER_MAJOR,szp_VER_MINOR,szp_VER_BUILD,szp_VER_REVISION};
+int szp_versionNumber[4] = {szp_VER_MAJOR, szp_VER_MINOR, szp_VER_BUILD, szp_VER_REVISION};
 
-int szp_dataEndianType = LITTLE_ENDIAN_DATA; //*endian type of the data read from disk
-int szp_sysEndianType = LITTLE_ENDIAN_SYSTEM; //*sysEndianType is actually set automatically.
-
+int szp_dataEndianType = LITTLE_ENDIAN_DATA;
+int szp_sysEndianType = LITTLE_ENDIAN_SYSTEM;
 using namespace szp;
 
-unsigned char *szp_compress(int fastMode, int dataType, void *data, size_t *outSize, int errBoundMode, float absErrBound,
-                                      float relBoundRatio, size_t nbEle, int blockSize)
+// --- FIX: Changed error bound parameters from float to double. ---
+unsigned char *szp_compress(int fastMode, int dataType, void *data, size_t *outSize, int errBoundMode, double absErrBound,
+                            double relBoundRatio, size_t nbEle, int blockSize)
 {
     unsigned char *bytes = NULL;
     size_t length = nbEle;
     size_t i = 0;
     if (dataType == SZ_FLOAT)
     {
-
-        float realPrecision = absErrBound;
+        // For float data, we cast the double precision down to float. This is the correct behavior.
+        float realPrecision = (float)absErrBound;
         if (errBoundMode == REL)
         {
             float *oriData = (float *)data;
@@ -46,37 +45,25 @@ unsigned char *szp_compress(int fastMode, int dataType, void *data, size_t *outS
                     max = v;
             }
             float valueRange = max - min;
-            realPrecision = valueRange * relBoundRatio;
-            //printf("REAL ERROR BOUND IS %20f\n", realPrecision);
-            if (fastMode == SZP_NONRANDOMACCESS)
-            {
-                bytes = szp_float_openmp_threadblock(oriData, outSize, realPrecision,
-                                                     length, blockSize);
-            }
-            else if (fastMode == SZP_RANDOMACCESS)
-            {
-                bytes = (unsigned char*) malloc(sizeof(float) + sizeof(float)*length);
-                szp_float_openmp_threadblock_randomaccess_args(bytes, oriData, outSize, realPrecision,
-                                                                  length, blockSize);
-            }
+            realPrecision = valueRange * (float)relBoundRatio;
         }
+
+        float *oriData = (float *)data;
         if (fastMode == SZP_NONRANDOMACCESS)
         {
-			float *oriData = (float *)data;
-            bytes = szp_float_openmp_threadblock(oriData, outSize, realPrecision,
-                                                 length, blockSize);
+            bytes = (unsigned char *)malloc(sizeof(float) + sizeof(float) * length);
+            szp_float_openmp_threadblock_arg(bytes, oriData, outSize, realPrecision,
+                                             length, blockSize);
         }
         else if (fastMode == SZP_RANDOMACCESS)
         {
-			float *oriData = (float *)data;
-			bytes = (unsigned char*) malloc(sizeof(float) + sizeof(float)*length);
-            szp_float_openmp_threadblock_randomaccess_args(bytes, oriData, outSize, realPrecision,
-                                                              length, blockSize);
+            bytes = (unsigned char *)malloc(sizeof(float) + sizeof(float) * length);
+            szp_float_openmp_threadblock_randomaccess_arg(bytes, oriData, outSize, realPrecision, length, blockSize);
         }
     }
-    else
+    else // SZ_DOUBLE
     {
-
+        // For double data, we now use the full double precision from the interface.
         double realPrecision = absErrBound;
         if (errBoundMode == REL)
         {
@@ -92,60 +79,65 @@ unsigned char *szp_compress(int fastMode, int dataType, void *data, size_t *outS
                     max = v;
             }
             double valueRange = max - min;
+            // This is now a full precision double-precision multiplication
             realPrecision = valueRange * relBoundRatio;
-            //printf("REAL ERROR BOUND IS %20f\n", realPrecision);
-            if (fastMode == SZP_NONRANDOMACCESS)
-            {
-                bytes = szp_double_openmp_threadblock(oriData, outSize, realPrecision,
-                                                     length, blockSize);
-            }
-            else if (fastMode == SZP_RANDOMACCESS)
-            {
-                bytes =  (unsigned char*)malloc(sizeof(double) + sizeof(double)*length);
-                szp_double_openmp_threadblock_randomaccess_args(bytes, oriData, outSize, realPrecision,
-                                                                  length, blockSize);
-            }
         }
+
+        double *oriData = (double *)data;
         if (fastMode == SZP_NONRANDOMACCESS)
         {
-			double *oriData = (double *)data;
-            bytes = szp_double_openmp_threadblock(oriData, outSize, realPrecision,
-                                                 length, blockSize);
+            bytes = (unsigned char *)malloc(sizeof(double) + sizeof(double) * length);
+            szp_double_openmp_threadblock_arg(bytes, oriData, outSize, realPrecision,
+                                              length, blockSize);
         }
         else if (fastMode == SZP_RANDOMACCESS)
         {
-			double *oriData = (double *)data;
-            bytes = (unsigned char*)malloc(sizeof(double) + sizeof(double)*length);
-            szp_double_openmp_threadblock_randomaccess_args(bytes, oriData, outSize, realPrecision,
-                                                              length, blockSize);
-        }        
+            bytes = (unsigned char *)malloc(sizeof(double) + sizeof(double) * length);
+            szp_double_openmp_threadblock_randomaccess_arg(bytes, oriData, outSize, realPrecision,
+                                                           length, blockSize);
+        }
     }
     return bytes;
 }
 
-void* szp_decompress(int fastMode, int dataType, unsigned char *bytes, size_t byteLength, size_t nbEle, int blockSize)
+void *szp_decompress(int fastMode, int dataType, unsigned char *bytes, size_t byteLength, size_t nbEle, int blockSize)
 {
     int x = 1;
-    char *y = (char*)&x;
-    if(*y==1)
+    char *y = (char *)&x;
+    if (*y == 1)
         szp_sysEndianType = LITTLE_ENDIAN_SYSTEM;
     else //=0
         szp_sysEndianType = BIG_ENDIAN_SYSTEM;
 
-    if(dataType == SZ_FLOAT)
+    if (dataType == SZ_FLOAT)
     {
-		float* decompressedData = (float*)malloc(nbEle*sizeof(float));
-		float absErrBound = bytesToFloat(bytes);
-		unsigned char* cmpBytes = bytes + sizeof(float);
-		szp_float_decompress_openmp_threadblock_randomaccess_args(&decompressedData, nbEle, absErrBound, blockSize, cmpBytes);
-		return decompressedData;
-	}
-	else //SZ_DOUBLE
-	{
-		double* decompressedData = (double*)malloc(nbEle*sizeof(double));
-		double absErrBound = bytesToDouble(bytes);
-		unsigned char* cmpBytes = bytes + sizeof(double);
-		szp_double_decompress_openmp_threadblock_randomaccess_args(&decompressedData, nbEle, absErrBound, blockSize, cmpBytes);
-		return decompressedData;
-	}
+        float *decompressedData = (float *)malloc(nbEle * sizeof(float));
+        float absErrBound = bytesToFloat(bytes);
+        unsigned char *cmpBytes = bytes + sizeof(float);
+        if (fastMode == SZP_NONRANDOMACCESS)
+        {
+            szp_float_decompress_openmp_threadblock_arg(decompressedData, nbEle, absErrBound, blockSize, cmpBytes);
+        }
+        else // SZP_RANDOMACCESS
+        {
+            szp_float_decompress_openmp_threadblock_randomaccess_arg(decompressedData, nbEle, absErrBound, blockSize, cmpBytes);
+        }
+        return decompressedData;
+    }
+    else // SZ_DOUBLE
+    {
+        double *decompressedData = (double *)malloc(nbEle * sizeof(double));
+        double absErrBound = bytesToDouble(bytes);
+        unsigned char *cmpBytes = bytes + sizeof(double);
+
+        if (fastMode == SZP_NONRANDOMACCESS)
+        {
+            szp_double_decompress_openmp_threadblock_arg(decompressedData, nbEle, absErrBound, blockSize, cmpBytes);
+        }
+        else // SZP_RANDOMACCESS
+        {
+            szp_double_decompress_openmp_threadblock_randomaccess_arg(decompressedData, nbEle, absErrBound, blockSize, cmpBytes);
+        }
+        return decompressedData;
+    }
 }

--- a/SZp/src/szp_double.cc
+++ b/SZp/src/szp_double.cc
@@ -1354,7 +1354,7 @@ size_t szp_double_single_thread_arg_record(unsigned char *output, double *oriDat
 }
 
 void 
-szp_double_openmp_threadblock_randomaccess_args(unsigned char* output, double *oriData, size_t *outSize, double absErrBound,
+szp_double_openmp_threadblock_randomaccess_arg(unsigned char* output, double *oriData, size_t *outSize, double absErrBound,
                                           size_t nbEle, int blockSize)
 {
 #ifdef _OPENMP

--- a/SZp/src/szp_float.cc
+++ b/SZp/src/szp_float.cc
@@ -1361,7 +1361,7 @@ size_t szp_float_single_thread_arg_record(unsigned char *output, float *oriData,
 }
 
 void
-szp_float_openmp_threadblock_randomaccess_args(unsigned char *output, float *oriData, size_t *outSize, float absErrBound,
+szp_float_openmp_threadblock_randomaccess_arg(unsigned char *output, float *oriData, size_t *outSize, float absErrBound,
                                           size_t nbEle, int blockSize)
 {
 #ifdef _OPENMP

--- a/SZp/src/szpd_double.cc
+++ b/SZp/src/szpd_double.cc
@@ -831,10 +831,10 @@ void szp_double_decompress_openmp_threadblock_arg(double *newData, size_t nbEle,
 #endif
 }
 
-void szp_double_decompress_openmp_threadblock_randomaccess_args(double **newData, size_t nbEle, double absErrBound, int blockSize, unsigned char *cmpBytes)
+void szp_double_decompress_openmp_threadblock_randomaccess_arg(double *newData, size_t nbEle, double absErrBound, int blockSize, unsigned char *cmpBytes)
 {
 #ifdef _OPENMP
-    *newData = (double *)malloc(sizeof(double) * nbEle);
+    // *newData = (double *)malloc(sizeof(double) * nbEle);
     size_t *offsets = (size_t *)cmpBytes;
     unsigned char *rcp;
     unsigned int nbThreads = 0;
@@ -859,7 +859,7 @@ void szp_double_decompress_openmp_threadblock_randomaccess_args(double **newData
         int tid = omp_get_thread_num();
         int lo = tid * threadblocksize;
         int hi = (tid + 1) * threadblocksize;
-        double *newData_perthread = *newData + lo;
+        double *newData_perthread = newData + lo;
         size_t i = 0;
         size_t j = 0;
         size_t k = 0;

--- a/SZp/src/szpd_float.cc
+++ b/SZp/src/szpd_float.cc
@@ -831,10 +831,10 @@ void szp_float_decompress_openmp_threadblock_arg(float *newData, size_t nbEle, f
 #endif
 }
 
-void szp_float_decompress_openmp_threadblock_randomaccess_args(float **newData, size_t nbEle, float absErrBound, int blockSize, unsigned char *cmpBytes)
+void szp_float_decompress_openmp_threadblock_randomaccess_arg(float *newData, size_t nbEle, float absErrBound, int blockSize, unsigned char *cmpBytes)
 {
 #ifdef _OPENMP
-    *newData = (float *)malloc(sizeof(float) * nbEle);
+    // *newData = (float *)malloc(sizeof(float) * nbEle);
     size_t *offsets = (size_t *)cmpBytes;
     unsigned char *rcp;
     unsigned int nbThreads = 0;
@@ -859,7 +859,7 @@ void szp_float_decompress_openmp_threadblock_randomaccess_args(float **newData, 
         int tid = omp_get_thread_num();
         int lo = tid * threadblocksize;
         int hi = (tid + 1) * threadblocksize;
-        float *newData_perthread = *newData + lo;
+        float *newData_perthread = newData + lo;
         size_t i = 0;
         size_t j = 0;
         size_t k = 0;


### PR DESCRIPTION
Fix:
1. in `SZp.cc`, the missing NON_RANDOM_ACCESS part is added;
2. in 'szpd_float.cc' and other related files, removed unnecessary memory allocations for `newData` in decompression;

Typo:
1. Standardized function names by replacing `*_args` with `*_arg`;

Extend:
1. Updated compression and decompression examples (`testfloat_compress_fastmode1.cc` and `testfloat_decompress_fastmode1.cc`) to support both `float` and `double` data types.
  - note: the `double` data types is still under testing, the function now may not work well.
2. Changed error bound parameters from `float` to `double` in `szp_compress` and related functions to improve precision.


### Precision Enhancements:
* Changed error bound parameters from `float` to `double` in `szp_compress` and related functions to improve precision. [[1]](diffhunk://#diff-541f07625b0b87aa6d383acb02d8765f62a0c3226b2b38a06965241ed3f07057L33-R34) [[2]](diffhunk://#diff-cf238a6f842fda988f9ae8ba514dd3e27a457f11a5e4312871cec79bfa9f1e0dL20-R33) [[3]](diffhunk://#diff-cf238a6f842fda988f9ae8ba514dd3e27a457f11a5e4312871cec79bfa9f1e0dR82-R96)

### Code Consistency:
* Standardized function names by replacing `*_args` with `*_arg` for better readability and consistency across files. [[1]](diffhunk://#diff-36f75681c5986789a644d493e36549a615e1588767740035826b46fab3b4ca64L43-R43) [[2]](diffhunk://#diff-1740edc10d2a4e7afc2188b11b17913b82861570ebfe00dd03057286fe4c8a10L43-R43) [[3]](diffhunk://#diff-fec0c6ed71e454d262fd3f1c1cce1e2d511f5588a2a843febcc5e2e5fe7bb195L29-R29) [[4]](diffhunk://#diff-b7b3877125b2cb3856fe85c3c18f559fec812bd7b6222e3a8bc9d30c75a883ecL29-R29) [[5]](diffhunk://#diff-36c06c0a35a828dcfd26b3df4eb4284d1b0f315448af5740ead4ae856269ba57L1357-R1357) [[6]](diffhunk://#diff-c1177639f5c4cffa304e5f168d9c4d2b5036ff8090fcd14eda204ea7f429be02L1364-R1364) [[7]](diffhunk://#diff-b11ae4df655c03a386d3dd2b764e0caedeccded30cd738c62e9f231d61148db9L834-R837) [[8]](diffhunk://#diff-752af0d083ad3773e4126aaeb2b2cc9ad51e3fdcc7beb8411dc6b8c4dbb744cbL834-R837)

### Extended Functionality:
* Updated compression and decompression examples (`testfloat_compress_fastmode1.cc` and `testfloat_decompress_fastmode1.cc`) to support both `float` and `double` data types. Added validation for data type input and adjusted logic to handle type-specific operations. [[1]](diffhunk://#diff-dd49e8978448d97bbb52dcd7db14b54b35f0e3310a9461cc1ab5afe2df37513aL36-R84) [[2]](diffhunk://#diff-91e28f91ddb1c94c4f3bef9cdc9af5b2a09a5fd78bd3921a970cdc3fb9cd9ca0L38-L55) [[3]](diffhunk://#diff-91e28f91ddb1c94c4f3bef9cdc9af5b2a09a5fd78bd3921a970cdc3fb9cd9ca0L67-R93)

### Minor Fixes and Improvements:
* Removed unnecessary memory allocations for `newData` in decompression functions to simplify code. [[1]](diffhunk://#diff-b11ae4df655c03a386d3dd2b764e0caedeccded30cd738c62e9f231d61148db9L862-R862) [[2]](diffhunk://#diff-752af0d083ad3773e4126aaeb2b2cc9ad51e3fdcc7beb8411dc6b8c4dbb744cbL862-R862)
* Fixed formatting issues and improved comments in `szp.cc` for better code clarity. [[1]](diffhunk://#diff-cf238a6f842fda988f9ae8ba514dd3e27a457f11a5e4312871cec79bfa9f1e0dL2-R8) [[2]](diffhunk://#diff-cf238a6f842fda988f9ae8ba514dd3e27a457f11a5e4312871cec79bfa9f1e0dL49-R66)

These changes collectively enhance the library's precision, usability, and maintainability.