### PR TITLE
Improve test file in example

### DIFF
--- a/SZp/src/szp_TypeManager.cc
+++ b/SZp/src/szp_TypeManager.cc
@@ -147,7 +147,7 @@ size_t Jiajun_convertUInt2Byte_fast_1b_args(unsigned int *intArray, size_t intAr
 
 size_t Jiajun_convertUInt2Byte_fast_2b_args(unsigned int *timeStepType, size_t timeStepTypeLength, unsigned char *result)
 {
-	register unsigned char tmp = 0;
+	unsigned char tmp = 0;
 	size_t i, byteLength = 0;
 	if (timeStepTypeLength % 4 == 0)
 		byteLength = timeStepTypeLength * 2 / 8;
@@ -251,43 +251,6 @@ size_t Jiajun_convertUInt2Byte_fast_3b_args(unsigned int *timeStepType, size_t t
 
 	return byteLength;
 }
-
-// size_t Jiajun_convertUInt2Byte_fast_3b_args(unsigned int *timeStepType, size_t timeStepTypeLength, unsigned char *result)
-// {
-//     size_t i = 0, k = 0, byteLength = 0, n = 0;
-//     if (timeStepTypeLength % 8 == 0)
-//         byteLength = timeStepTypeLength * 3 / 8;
-//     else
-//         byteLength = timeStepTypeLength * 3 / 8 + 1;
- 
-//     unsigned char tmp = 0;
-//     for (n = 0; n < timeStepTypeLength; n++)
-//     {
-//         k = n % 8;
-//         // 直接从高位获取3位，而不是清除低位后从最低位获取
-//         unsigned char bits = (timeStepType[n] >> (32 - 3)) & 0x07; // 获取最高3位
-        
-//         switch (k)
-//         {
-//         case 0:
-//             tmp = tmp | (bits << 5);
-//             break;
-//         case 1:
-//             tmp = tmp | (bits << 2);
-//             break;
-//         case 2:
-//             tmp = tmp | (bits >> 1);
-//             (result)[i++] = tmp;
-//             tmp = 0 | (bits << 7);
-//             break;
-//         // ... 其他case类似修改
-//         }
-//     }
-//     if (k != 7) 
-//         (result)[i] = tmp;
- 
-//     return byteLength;
-// }
 
 size_t Jiajun_convertUInt2Byte_fast_4b_args(unsigned int *timeStepType, size_t timeStepTypeLength, unsigned char *result)
 {
@@ -1037,7 +1000,7 @@ void convertByteArray2IntArray_fast_1b(size_t intArrayLength, unsigned char *byt
 
 inline size_t convertIntArray2ByteArray_fast_2b_args(unsigned char *timeStepType, size_t timeStepTypeLength, unsigned char *result)
 {
-	register unsigned char tmp = 0;
+	unsigned char tmp = 0;
 	size_t i, byteLength = 0;
 	if (timeStepTypeLength % 4 == 0)
 		byteLength = timeStepTypeLength * 2 / 8;

--- a/SZp/src/szp_TypeManager.cc
+++ b/SZp/src/szp_TypeManager.cc
@@ -252,6 +252,43 @@ size_t Jiajun_convertUInt2Byte_fast_3b_args(unsigned int *timeStepType, size_t t
 	return byteLength;
 }
 
+// size_t Jiajun_convertUInt2Byte_fast_3b_args(unsigned int *timeStepType, size_t timeStepTypeLength, unsigned char *result)
+// {
+//     size_t i = 0, k = 0, byteLength = 0, n = 0;
+//     if (timeStepTypeLength % 8 == 0)
+//         byteLength = timeStepTypeLength * 3 / 8;
+//     else
+//         byteLength = timeStepTypeLength * 3 / 8 + 1;
+ 
+//     unsigned char tmp = 0;
+//     for (n = 0; n < timeStepTypeLength; n++)
+//     {
+//         k = n % 8;
+//         // 直接从高位获取3位，而不是清除低位后从最低位获取
+//         unsigned char bits = (timeStepType[n] >> (32 - 3)) & 0x07; // 获取最高3位
+        
+//         switch (k)
+//         {
+//         case 0:
+//             tmp = tmp | (bits << 5);
+//             break;
+//         case 1:
+//             tmp = tmp | (bits << 2);
+//             break;
+//         case 2:
+//             tmp = tmp | (bits >> 1);
+//             (result)[i++] = tmp;
+//             tmp = 0 | (bits << 7);
+//             break;
+//         // ... 其他case类似修改
+//         }
+//     }
+//     if (k != 7) 
+//         (result)[i] = tmp;
+ 
+//     return byteLength;
+// }
+
 size_t Jiajun_convertUInt2Byte_fast_4b_args(unsigned int *timeStepType, size_t timeStepTypeLength, unsigned char *result)
 {
 	size_t i = 0, byteLength = 0, n = 0;

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -6,9 +6,11 @@ if OPENMP
 AM_CXXFLAGS+=-fopenmp
 endif
 
-bin_PROGRAMS=testfloat_compress_fastmode1 testfloat_decompress_fastmode1
+bin_PROGRAMS=testfloat_compress_fastmode1 testfloat_decompress_fastmode1 test_multidim
 
 testfloat_compress_fastmode1_SOURCES=testfloat_compress_fastmode1.cc
 testfloat_compress_fastmode1_LDADD=../SZp/.libs/libszp.a -lm
 testfloat_decompress_fastmode1_SOURCES=testfloat_decompress_fastmode1.cc
 testfloat_decompress_fastmode1_LDADD=../SZp/.libs/libszp.a -lm
+test_multidim_SOURCES=test_multidim.cc
+test_multidim_LDADD=../SZp/.libs/libszp.a -lm

--- a/example/test_multidim.cc
+++ b/example/test_multidim.cc
@@ -1,0 +1,288 @@
+/**
+ *  @file test_multidim.cc
+ *  @author Jiefeng Zhou
+ *  @date Aug, 2025
+ *  @brief A benchmark tool for compressing and decompressing multi-dimensional datasets.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include "szp.h"
+#include <sys/time.h>
+#include <vector>
+#include <algorithm>
+#include <numeric>
+
+// --- Utility Functions ---
+
+double totalCost = 0;
+struct timeval costStart;
+
+void cost_start() {
+    gettimeofday(&costStart, NULL);
+}
+
+void cost_end() {
+    struct timeval costEnd;
+    gettimeofday(&costEnd, NULL);
+    totalCost = ((costEnd.tv_sec * 1000000 + costEnd.tv_usec) - (costStart.tv_sec * 1000000 + costStart.tv_usec)) / 1000000.0;
+}
+
+// --- Result Structures and Analysis ---
+
+struct CompResult {
+    double timeCost;
+    size_t compressedSize;
+    double compressionRatio;
+};
+
+struct DecompResult {
+    double timeCost;
+    double maxAbsErr;
+    double psnr;
+    double nrmse;
+    double compressionRatio;
+};
+
+// --- Compression Statistics ---
+void writeCompToCsv(const char* filename, const std::vector<CompResult>& results) {
+    FILE* fp = fopen(filename, "w");
+    if (!fp) return;
+    fprintf(fp, "Run,TimeSeconds,CompressedSize,CompressionRatio\n");
+    for (size_t i = 0; i < results.size(); i++) {
+        fprintf(fp, "%zu,%.6f,%zu,%.2f\n", i + 1, results[i].timeCost, results[i].compressedSize, results[i].compressionRatio);
+    }
+    fclose(fp);
+}
+
+void calculateCompStats(const std::vector<CompResult>& results) {
+    if (results.empty()) return;
+    std::vector<double> times, crs;
+    for(const auto& res : results) {
+        times.push_back(res.timeCost);
+        crs.push_back(res.compressionRatio);
+    }
+    
+    double timeAvg = std::accumulate(times.begin(), times.end(), 0.0) / times.size();
+    double crAvg = std::accumulate(crs.begin(), crs.end(), 0.0) / crs.size();
+    
+    double timeStdDev = 0.0;
+    for(const auto& t : times) timeStdDev += (t - timeAvg) * (t - timeAvg);
+    timeStdDev = sqrt(timeStdDev / times.size());
+
+    double crStdDev = 0.0;
+    for(const auto& cr : crs) crStdDev += (cr - crAvg) * (cr - crAvg);
+    crStdDev = sqrt(crStdDev / crs.size());
+
+    printf("\n======= Compression Performance (over %zu runs) =======\n", results.size());
+    printf("Time (s):   Avg=%.6f, StdDev=%.6f\n", timeAvg, timeStdDev);
+    printf("Comp Ratio: Avg=%.2f, StdDev=%.2f\n", crAvg, crStdDev);
+    printf("======================================================\n");
+}
+
+
+// --- Decompression Statistics ---
+void writeDecompToCsv(const char* filename, const std::vector<DecompResult>& results) {
+    FILE* fp = fopen(filename, "w");
+    if (!fp) return;
+    fprintf(fp, "Run,TimeSeconds,MaxAbsErr,PSNR,NRMSE,CompressionRatio\n");
+    for (size_t i = 0; i < results.size(); i++) {
+        fprintf(fp, "%zu,%.6f,%.6e,%.4f,%.6e,%.2f\n", i + 1, results[i].timeCost, results[i].maxAbsErr, results[i].psnr, results[i].nrmse, results[i].compressionRatio);
+    }
+    fclose(fp);
+}
+
+void calculateDecompStats(const std::vector<DecompResult>& results) {
+    if (results.empty()) return;
+    std::vector<double> times, psnrs;
+    for(const auto& res : results) {
+        times.push_back(res.timeCost);
+        psnrs.push_back(res.psnr);
+    }
+
+    double timeAvg = std::accumulate(times.begin(), times.end(), 0.0) / times.size();
+    double psnrAvg = std::accumulate(psnrs.begin(), psnrs.end(), 0.0) / psnrs.size();
+
+    double timeStdDev = 0.0;
+    for(const auto& t : times) timeStdDev += (t - timeAvg) * (t - timeAvg);
+    timeStdDev = sqrt(timeStdDev / times.size());
+
+    double psnrStdDev = 0.0;
+    for(const auto& p : psnrs) psnrStdDev += (p - psnrAvg) * (p - psnrAvg);
+    psnrStdDev = sqrt(psnrStdDev / psnrs.size());
+
+    printf("\n======= Decompression Performance (over %zu runs) =======\n", results.size());
+    printf("Time (s): Avg=%.6f, StdDev=%.6f\n", timeAvg, timeStdDev);
+    printf("PSNR:     Avg=%.4f, StdDev=%.4f\n", psnrAvg, psnrStdDev);
+    printf("=========================================================\n");
+}
+
+
+template<typename T>
+DecompResult evaluate(const T* ori_data, const T* dec_data, size_t num_elements, size_t compressed_size) {
+    DecompResult res;
+    double max_val = ori_data[0], min_val = ori_data[0], max_abs_err = 0.0, mse = 0.0;
+
+    for (size_t i = 0; i < num_elements; ++i) {
+        if (ori_data[i] > max_val) max_val = ori_data[i];
+        if (ori_data[i] < min_val) min_val = ori_data[i];
+        double abs_err = fabs((double)ori_data[i] - (double)dec_data[i]);
+        if (abs_err > max_abs_err) max_abs_err = abs_err;
+        mse += abs_err * abs_err;
+    }
+    mse /= num_elements;
+    double value_range = max_val - min_val;
+    
+    res.maxAbsErr = max_abs_err;
+    res.psnr = (mse == 0) ? 999.99 : 20 * log10(value_range) - 10 * log10(mse);
+    res.nrmse = (value_range == 0) ? 0 : sqrt(mse) / value_range;
+    res.compressionRatio = (double)(num_elements * sizeof(T)) / compressed_size;
+
+    printf("  Max Abs Error: %.6e, PSNR: %.4f, NRMSE: %.6e, CR: %.2f\n", res.maxAbsErr, res.psnr, res.nrmse, res.compressionRatio);
+    return res;
+}
+
+// --- Main Logic ---
+
+void print_usage() {
+    printf("Usage: test_multidim <mode> <options>\n");
+    printf("\n  Mode: -c (compress) or -d (decompress)\n");
+    printf("\n  Compress Mode:\n");
+    printf("    ./test_multidim -c <filepath> <dtype> <err_bound> <block_size> <dims...> [-r reps] [-w warmups] [-o out.csv]\n");
+    printf("    Example: ./test_multidim -c temp.f32 float 1e-4 128 512 512 512 -r 10 -w 2\n");
+    printf("\n  Decompress Mode:\n");
+    printf("    ./test_multidim -d <compressed_file> <dtype> <block_size> <dims...> [-r reps] [-w warmups] [-o out.csv]\n");
+    printf("    Example: ./test_multidim -d temp.f32.szp float 128 512 512 512\n");
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        print_usage();
+        return 1;
+    }
+
+    bool compress_mode = (strcmp(argv[1], "-c") == 0);
+    bool decompress_mode = (strcmp(argv[1], "-d") == 0);
+
+    if (!compress_mode && !decompress_mode) {
+        print_usage();
+        return 1;
+    }
+
+    // --- Argument Parsing ---
+    const char* filepath = argv[2];
+    const char* datatype_str = argv[3];
+    double err_bound = compress_mode ? atof(argv[4]) : 0;
+    int block_size = compress_mode ? atoi(argv[5]) : atoi(argv[4]);
+    
+    int dim_start_index = compress_mode ? 6 : 5;
+    size_t num_elements = 1;
+    int current_arg = dim_start_index;
+    while (current_arg < argc && argv[current_arg][0] != '-') {
+        num_elements *= (size_t)atol(argv[current_arg]);
+        current_arg++;
+    }
+
+    int repetitions = 1, warmupRuns = 0;
+    char csvFilePath[256] = {0};
+    while (current_arg < argc) {
+        if (strcmp(argv[current_arg], "-r") == 0) repetitions = atoi(argv[++current_arg]);
+        else if (strcmp(argv[current_arg], "-w") == 0) warmupRuns = atoi(argv[++current_arg]);
+        else if (strcmp(argv[current_arg], "-o") == 0) sprintf(csvFilePath, "%s", argv[++current_arg]);
+        current_arg++;
+    }
+
+    int sz_datatype = (strcmp(datatype_str, "float") == 0) ? SZ_FLOAT : SZ_DOUBLE;
+    size_t dtype_size = (sz_datatype == SZ_FLOAT) ? sizeof(float) : sizeof(double);
+
+    // --- Compression Logic ---
+    if (compress_mode) {
+        int status;
+        void* data = (sz_datatype == SZ_FLOAT) ? (void*)szp_readFloatData((char*)filepath, &num_elements, &status) : (void*)szp_readDoubleData((char*)filepath, &num_elements, &status);
+        if (status != SZ_SCES) {
+            fprintf(stderr, "Error reading %s\n", filepath);
+            return 1;
+        }
+
+        printf("--- Compressing %s ---\n", filepath);
+        std::vector<CompResult> results;
+        for (int i = 0; i < warmupRuns + repetitions; ++i) {
+            size_t compressed_size;
+            cost_start();
+            unsigned char* bytes = szp_compress(SZP_RANDOMACCESS, sz_datatype, data, &compressed_size, ABS, err_bound, 0, num_elements, block_size);
+            cost_end();
+
+            if (i < warmupRuns) {
+                printf("Warmup %d/%d: Time=%.4fs\n", i + 1, warmupRuns, totalCost);
+            } else {
+                printf("Run %d/%d: Time=%.4fs, Size=%zu, CR=%.2f\n", i - warmupRuns + 1, repetitions, totalCost, compressed_size, (double)(num_elements * dtype_size) / compressed_size);
+                CompResult res = {totalCost, compressed_size, (double)(num_elements * dtype_size) / compressed_size};
+                results.push_back(res);
+                if (i == warmupRuns + repetitions - 1) {
+                    char outpath[256];
+                    sprintf(outpath, "%s.szp", filepath);
+                    szp_writeByteData(bytes, compressed_size, outpath, &status);
+                    printf("Compressed data written to %s\n", outpath);
+                }
+            }
+            free(bytes);
+        }
+        free(data);
+        if (results.size() > 1) calculateCompStats(results);
+        if (csvFilePath[0]) writeCompToCsv(csvFilePath, results);
+    }
+
+    // --- Decompression Logic ---
+    if (decompress_mode) {
+        int status;
+        size_t compressed_size;
+        unsigned char* bytes = szp_readByteData((char*)filepath, &compressed_size, &status);
+        if (status != SZ_SCES) {
+            fprintf(stderr, "Error reading %s\n", filepath);
+            return 1;
+        }
+
+        char oriFilePath[256];
+        strcpy(oriFilePath, filepath);
+        oriFilePath[strlen(filepath) - 4] = '\0'; // Remove .szp
+        void* ori_data = (sz_datatype == SZ_FLOAT) ? (void*)szp_readFloatData(oriFilePath, &num_elements, &status) : (void*)szp_readDoubleData(oriFilePath, &num_elements, &status);
+        if (status != SZ_SCES) {
+            fprintf(stderr, "Error reading original file %s for verification\n", oriFilePath);
+            free(bytes);
+            return 1;
+        }
+
+        printf("--- Decompressing %s ---\n", filepath);
+        std::vector<DecompResult> results;
+        for (int i = 0; i < warmupRuns + repetitions; ++i) {
+            cost_start();
+            void* dec_data = szp_decompress(SZP_RANDOMACCESS, sz_datatype, bytes, compressed_size, num_elements, block_size);
+            cost_end();
+
+            if (i < warmupRuns) {
+                printf("Warmup %d/%d: Time=%.4fs\n", i + 1, warmupRuns, totalCost);
+            } else {
+                printf("Run %d/%d: Time=%.4fs\n", i - warmupRuns + 1, repetitions, totalCost);
+                DecompResult res = (sz_datatype == SZ_FLOAT) ? evaluate((float*)ori_data, (float*)dec_data, num_elements, compressed_size) : evaluate((double*)ori_data, (double*)dec_data, num_elements, compressed_size);
+                res.timeCost = totalCost;
+                results.push_back(res);
+                if (i == warmupRuns + repetitions - 1) {
+                    char outpath[256];
+                    sprintf(outpath, "%s.out", filepath);
+                    if(sz_datatype == SZ_FLOAT) szp_writeFloatData_inBytes((float*)dec_data, num_elements, outpath, &status);
+                    else szp_writeDoubleData_inBytes((double*)dec_data, num_elements, outpath, &status);
+                    printf("Decompressed data written to %s\n", outpath);
+                }
+            }
+            free(dec_data);
+        }
+        free(bytes);
+        free(ori_data);
+        if (results.size() > 1) calculateDecompStats(results);
+        if (csvFilePath[0]) writeDecompToCsv(csvFilePath, results);
+    }
+
+    return 0;
+}

--- a/example/testfloat_compress_fastmode1.cc
+++ b/example/testfloat_compress_fastmode1.cc
@@ -1,112 +1,269 @@
 /**
- *  @file szp_Float.h
- *  @author Jiajun Huang, Sheng Di
- *  @date Oct, 2023
+ *  @file testfloat_compress_fastmode1.cc
+ *  @author Jiajun Huang, Sheng Di (modified by Jeffey Chou)
+ *  @date Oct, 2023 (modified Aug, 2025)
  */
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
 #include "szp.h"
 #ifdef _OPENMP
 #include "omp.h"
 #endif
+#include <sys/time.h>
+#include <vector>
+#include <algorithm>
+
 struct timeval startTime;
 struct timeval endTime;   /* Start and end times */
 struct timeval costStart; /*only used for recording the cost*/
 double totalCost = 0;
 
+// Structure to hold benchmark results
+typedef struct {
+    double timeCost;
+    size_t compressedSize;
+    double compressionRatio;
+} BenchmarkResult;
+
+// Function to write results to CSV file
+void writeToCsv(const char* filename, const std::vector<BenchmarkResult>& results) {
+    FILE* fp = fopen(filename, "w");
+    if (!fp) {
+        printf("Error: Cannot open file %s for writing\n", filename);
+        return;
+    }
+    
+    fprintf(fp, "Run,TimeSeconds,CompressionSize,CompressionRatio\n");
+    for (size_t i = 0; i < results.size(); i++) {
+        fprintf(fp, "%zu,%f,%zu,%f\n", i+1, results[i].timeCost, 
+                results[i].compressedSize, results[i].compressionRatio);
+    }
+    fclose(fp);
+}
+
+// Function to calculate statistics on benchmark results
+void calculateStats(const std::vector<BenchmarkResult>& results) {
+    if (results.empty()) return;
+    
+    // Time statistics
+    double timeSum = 0, timeMin = results[0].timeCost, timeMax = results[0].timeCost;
+    for (const auto& res : results) {
+        timeSum += res.timeCost;
+        timeMin = std::min(timeMin, res.timeCost);
+        timeMax = std::max(timeMax, res.timeCost);
+    }
+    double timeAvg = timeSum / results.size();
+    
+    double timeVariance = 0;
+    for (const auto& res : results) {
+        timeVariance += (res.timeCost - timeAvg) * (res.timeCost - timeAvg);
+    }
+    double timeStdDev = sqrt(timeVariance / results.size());
+    
+    // CR statistics
+    double crSum = 0, crMin = results[0].compressionRatio, crMax = results[0].compressionRatio;
+    for (const auto& res : results) {
+        crSum += res.compressionRatio;
+        crMin = std::min(crMin, res.compressionRatio);
+        crMax = std::max(crMax, res.compressionRatio);
+    }
+    double crAvg = crSum / results.size();
+    
+    double crVariance = 0;
+    for (const auto& res : results) {
+        crVariance += (res.compressionRatio - crAvg) * (res.compressionRatio - crAvg);
+    }
+    double crStdDev = sqrt(crVariance / results.size());
+    
+    // Print statistics
+    printf("\n======= Performance Statistics (excluding warmup runs) =======\n");
+    printf("Time (seconds): Min=%.6f, Max=%.6f, Avg=%.6f, StdDev=%.6f\n", 
+           timeMin, timeMax, timeAvg, timeStdDev);
+    printf("Compression Ratio: Min=%.6f, Max=%.6f, Avg=%.6f, StdDev=%.6f\n", 
+           crMin, crMax, crAvg, crStdDev);
+    printf("===========================================================\n");
+}
+
 void cost_start()
 {
-  totalCost = 0;
-  gettimeofday(&costStart, NULL);
+    totalCost = 0;
+    gettimeofday(&costStart, NULL);
 }
 
 void cost_end()
 {
-  double elapsed;
-  struct timeval costEnd;
-  gettimeofday(&costEnd, NULL);
-  elapsed = ((costEnd.tv_sec * 1000000 + costEnd.tv_usec) - (costStart.tv_sec * 1000000 + costStart.tv_usec)) / 1000000.0;
-  totalCost += elapsed;
+    double elapsed;
+    struct timeval costEnd;
+    gettimeofday(&costEnd, NULL);
+    elapsed = ((costEnd.tv_sec * 1000000 + costEnd.tv_usec) - (costStart.tv_sec * 1000000 + costStart.tv_usec)) / 1000000.0;
+    totalCost += elapsed;
+}
+
+void printUsage() {
+    printf("Usage: testfloat_compress_fastmode1 [srcFilePath] [block size] [err bound] [data_type] [access_type] [repetitions] [warmup_runs] [output_csv]\n");
+    printf("Example: testfloat_compress_fastmode1 testfloat_8_8_128.dat 64 1E-3 float random 10 2 results.csv\n");
+    printf("  - repetitions, warmup_runs, and output_csv are optional\n");
 }
 
 int main(int argc, char *argv[])
 {
-  char oriFilePath[640], outputFilePath[645];
-  if (argc < 5)
-  {
-    printf("Usage: testfloat_compress_fastmode1 [srcFilePath] [block size] [err bound] [data_type] [access_type]\n");
-    printf("Example: testfloat_compress_fastmode1 testfloat_8_8_128.dat 64 1E-3 float random\n");
-    exit(0);
-  }
+    char oriFilePath[640], outputFilePath[645], csvFilePath[650] = {0};
+    if (argc < 6)
+    {
+        printUsage();
+        exit(0);
+    }
 
-  sprintf(oriFilePath, "%s", argv[1]);
-  int blockSize = atoi(argv[2]);
-  double errBound = atof(argv[3]);
-  char* dataType = argv[4];
-  char* accessType = argv[5];
-  int sz_dataType = SZ_FLOAT;
-  int accessMode = SZP_RANDOMACCESS;
+    sprintf(oriFilePath, "%s", argv[1]);
+    int blockSize = atoi(argv[2]);
+    double errBound = atof(argv[3]);
+    char* dataType = argv[4];
+    char* accessType = argv[5];
+    
+    // Benchmark parameters - default values
+    int repetitions = 1;
+    int warmupRuns = 0;
+    
+    // Parse optional benchmark parameters
+    if (argc >= 7) repetitions = atoi(argv[6]);
+    if (argc >= 8) warmupRuns = atoi(argv[7]);
+    if (argc >= 9) sprintf(csvFilePath, "%s", argv[8]);
+    
+    int sz_dataType = SZ_FLOAT;
+    int accessMode = SZP_RANDOMACCESS;
 
-  if (strcmp(dataType, "float") != 0 && strcmp(dataType, "double") != 0)
-  {
-    printf("Error: data type must be 'float' or 'double'!\n");
-    exit(0);
-  }
-  if (strcmp(dataType, "double") == 0)
-  {
-    sz_dataType = SZ_DOUBLE;
-  }
+    if (strcmp(dataType, "float") != 0 && strcmp(dataType, "double") != 0)
+    {
+        printf("Error: data type must be 'float' or 'double'!\n");
+        exit(0);
+    }
+    if (strcmp(dataType, "double") == 0)
+    {
+        sz_dataType = SZ_DOUBLE;
+    }
 
-  if (strcmp(accessType, "random") == 0)
-  {
-    accessMode = SZP_RANDOMACCESS;
-  }
-  else if (strcmp(accessType, "nonrandom") == 0)
-  {
-    accessMode = SZP_NONRANDOMACCESS;
-  }
-  else
-  {
-    printf("Error: access type must be 'random' or 'nonrandom'!\n");
-    exit(0);
-  }
+    if (strcmp(accessType, "random") == 0)
+    {
+        accessMode = SZP_RANDOMACCESS;
+    }
+    else if (strcmp(accessType, "nonrandom") == 0)
+    {
+        accessMode = SZP_NONRANDOMACCESS;
+    }
+    else
+    {
+        printf("Error: access type must be 'random' or 'nonrandom'!\n");
+        exit(0);
+    }
 
-  sprintf(outputFilePath, "%s.szp", oriFilePath);
+    sprintf(outputFilePath, "%s.szp", oriFilePath);
 
-  int status = 0;
-  size_t nbEle;
-  void *data;
-  if (sz_dataType == SZ_FLOAT)
-  {
-    data = szp_readFloatData(oriFilePath, &nbEle, &status);
-  }
-  else // SZ_DOUBLE
-  {
-    data = szp_readDoubleData(oriFilePath, &nbEle, &status);
-  }
-  if (status != SZ_SCES)
-  {
-    printf("Error: data file %s cannot be read!\n", oriFilePath);
-    exit(0);
-  }
+    // Print benchmark configuration
+    printf("SZp Compression Benchmark Configuration\n");
+    printf("======================================\n");
+    printf("Input file: %s\n", oriFilePath);
+    printf("Block size: %d\n", blockSize);
+    printf("Error bound: %g\n", errBound);
+    printf("Data type: %s\n", dataType);
+    printf("Access type: %s\n", accessType);
+    printf("Repetitions: %d\n", repetitions);
+    printf("Warmup runs: %d\n", warmupRuns);
+    if (csvFilePath[0]) printf("CSV output: %s\n", csvFilePath);
+    printf("======================================\n\n");
 
-  size_t outSize;
-  cost_start();
-  unsigned char *bytes = szp_compress(accessMode, sz_dataType, data, &outSize, ABS, errBound, 0, nbEle, blockSize);
-  cost_end();
-  printf("\ntimecost=%f, total fastmode1\n", totalCost);
-  printf("compression size = %zu, CR = %f, writing to %s\n", outSize, 1.0f * nbEle * ((sz_dataType == SZ_FLOAT) ? sizeof(float) : sizeof(double))/ outSize, outputFilePath);
-  szp_writeByteData(bytes, outSize, outputFilePath, &status);
-  if (status != SZ_SCES)
-  {
-    printf("Error: data file %s cannot be written!\n", outputFilePath);
-    exit(0);
-  }
+    // Read data only once
+    int status = 0;
+    size_t nbEle;
+    void *data;
+    printf("Reading input data...\n");
+    if (sz_dataType == SZ_FLOAT)
+    {
+        data = szp_readFloatData(oriFilePath, &nbEle, &status);
+    }
+    else // SZ_DOUBLE
+    {
+        data = szp_readDoubleData(oriFilePath, &nbEle, &status);
+    }
+    if (status != SZ_SCES)
+    {
+        printf("Error: data file %s cannot be read!\n", oriFilePath);
+        exit(0);
+    }
+    printf("Data elements: %zu\n", nbEle);
 
-  printf("done\n");
-  free(bytes);
-  free(data);
+    // Vector to store benchmark results (excluding warmup runs)
+    std::vector<BenchmarkResult> results;
 
-  return 0;
+    // Perform warmup runs (results not recorded)
+    if (warmupRuns > 0) {
+        printf("\nPerforming %d warmup runs...\n", warmupRuns);
+        for (int i = 0; i < warmupRuns; i++) {
+            printf("  Warmup run %d of %d: ", i+1, warmupRuns);
+            
+            size_t outSize;
+            cost_start();
+            unsigned char *bytes = szp_compress(accessMode, sz_dataType, data, &outSize, 
+                                               ABS, errBound, 0, nbEle, blockSize);
+            cost_end();
+            
+            printf("time=%f, size=%zu, CR=%f\n", 
+                   totalCost, outSize, 
+                   1.0f * nbEle * ((sz_dataType == SZ_FLOAT) ? sizeof(float) : sizeof(double)) / outSize);
+            
+            free(bytes);
+        }
+    }
+
+    // Perform actual benchmark runs
+    printf("\nStarting %d benchmark runs...\n", repetitions);
+    for (int i = 0; i < repetitions; i++) {
+        printf("\nRun %d of %d:\n", i+1, repetitions);
+        
+        size_t outSize;
+        cost_start();
+        unsigned char *bytes = szp_compress(accessMode, sz_dataType, data, &outSize, 
+                                           ABS, errBound, 0, nbEle, blockSize);
+        cost_end();
+        
+        double compressionRatio = 1.0f * nbEle * ((sz_dataType == SZ_FLOAT) ? sizeof(float) : sizeof(double)) / outSize;
+        printf("  timecost=%f, compression size=%zu, CR=%f\n", totalCost, outSize, compressionRatio);
+        
+        // Save result
+        BenchmarkResult result;
+        result.timeCost = totalCost;
+        result.compressedSize = outSize;
+        result.compressionRatio = compressionRatio;
+        results.push_back(result);
+        
+        // Write compressed data to file only on the last run
+        if (i == repetitions - 1) {
+            printf("  Writing compressed data to %s\n", outputFilePath);
+            szp_writeByteData(bytes, outSize, outputFilePath, &status);
+            if (status != SZ_SCES) {
+                printf("Error: data file %s cannot be written!\n", outputFilePath);
+            }
+        }
+        
+        free(bytes);
+    }
+
+    // Calculate and print statistics
+    if (results.size() > 1) {
+        calculateStats(results);
+    }
+    
+    // Write to CSV if requested
+    if (csvFilePath[0]) {
+        writeToCsv(csvFilePath, results);
+        printf("Results written to CSV: %s\n", csvFilePath);
+    }
+
+    printf("\nBenchmark completed.\n");
+    free(data);
+
+    return 0;
 }

--- a/example/testfloat_decompress_fastmode1.cc
+++ b/example/testfloat_decompress_fastmode1.cc
@@ -1,26 +1,100 @@
 /**
- *  @file testfloat_decompress_fastmode1.c
- *  @author Sheng Di
- *  @date April, 2015
- *  @brief This is an example of using Decompression interface.
- *  (C) 2015 by Mathematics and Computer Science (MCS), Argonne National Laboratory.
- *      See COPYRIGHT in top-level directory.
+ *  @file testfloat_decompress_fastmode1.cc
+ *  @author Sheng Di (modified by Jeffey Chou)
+ *  @date April, 2015 (modified Aug, 2025)
+ *  @brief This is an example of using Decompression interface with integrated benchmarking.
  */
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#include <math.h>
 #include "szp.h"
 #include <sys/time.h>
 #ifdef _OPENMP
 #include "omp.h"
 #endif
+#include <vector>
+#include <algorithm>
 
 struct timeval startTime;
 struct timeval endTime;   /* Start and end times */
 struct timeval costStart; /*only used for recording the cost*/
 double totalCost = 0;
+
+// Structure to hold benchmark results
+typedef struct {
+    double timeCost;
+    double maxAbsErr;
+    double maxRelErr;
+    double maxPwRelErr;
+    double psnr;
+    double nrmse;
+    double acEff;
+    double compressionRatio;
+} BenchmarkResult;
+
+// Function to write results to CSV file
+void writeToCsv(const char* filename, const std::vector<BenchmarkResult>& results) {
+    FILE* fp = fopen(filename, "w");
+    if (!fp) {
+        printf("Error: Cannot open file %s for writing\n", filename);
+        return;
+    }
+    
+    fprintf(fp, "Run,TimeSeconds,MaxAbsErr,MaxRelErr,MaxPwRelErr,PSNR,NRMSE,AccEff,CompressionRatio\n");
+    for (size_t i = 0; i < results.size(); i++) {
+        fprintf(fp, "%zu,%f,%f,%f,%f,%f,%e,%f,%f\n", i+1, 
+                results[i].timeCost, results[i].maxAbsErr, results[i].maxRelErr,
+                results[i].maxPwRelErr, results[i].psnr, results[i].nrmse,
+                results[i].acEff, results[i].compressionRatio);
+    }
+    fclose(fp);
+}
+
+// Function to calculate statistics on benchmark results
+void calculateStats(const std::vector<BenchmarkResult>& results) {
+    if (results.empty()) return;
+    
+    // Time statistics
+    double timeSum = 0, timeMin = results[0].timeCost, timeMax = results[0].timeCost;
+    for (const auto& res : results) {
+        timeSum += res.timeCost;
+        timeMin = std::min(timeMin, res.timeCost);
+        timeMax = std::max(timeMax, res.timeCost);
+    }
+    double timeAvg = timeSum / results.size();
+    
+    double timeVariance = 0;
+    for (const auto& res : results) {
+        timeVariance += (res.timeCost - timeAvg) * (res.timeCost - timeAvg);
+    }
+    double timeStdDev = sqrt(timeVariance / results.size());
+    
+    // PSNR statistics
+    double psnrSum = 0, psnrMin = results[0].psnr, psnrMax = results[0].psnr;
+    for (const auto& res : results) {
+        psnrSum += res.psnr;
+        psnrMin = std::min(psnrMin, res.psnr);
+        psnrMax = std::max(psnrMax, res.psnr);
+    }
+    double psnrAvg = psnrSum / results.size();
+    
+    double psnrVariance = 0;
+    for (const auto& res : results) {
+        psnrVariance += (res.psnr - psnrAvg) * (res.psnr - psnrAvg);
+    }
+    double psnrStdDev = sqrt(psnrVariance / results.size());
+    
+    // Print statistics
+    printf("\n======= Performance Statistics (excluding warmup runs) =======\n");
+    printf("Time (seconds): Min=%.6f, Max=%.6f, Avg=%.6f, StdDev=%.6f\n", 
+           timeMin, timeMax, timeAvg, timeStdDev);
+    printf("PSNR: Min=%.6f, Max=%.6f, Avg=%.6f, StdDev=%.6f\n", 
+           psnrMin, psnrMax, psnrAvg, psnrStdDev);
+    printf("===========================================================\n");
+}
 
 void cost_start()
 {
@@ -36,112 +110,18 @@ void cost_end()
     elapsed = ((costEnd.tv_sec * 1000000 + costEnd.tv_usec) - (costStart.tv_sec * 1000000 + costStart.tv_usec)) / 1000000.0;
     totalCost += elapsed;
 }
-int main(int argc, char *argv[])
-{
-    size_t nbEle, totalNbEle;
-    char zipFilePath[640], outputFilePath[645];
-    if (argc < 6) // Updated argument count check
-    {
-        printf("Usage: testfloat_decompress_fastmode1 [srcFilePath] [nbEle] [block size] [data_type] [access_type]\n");
-        printf("Example: testfloat_decompress_fastmode1 testfloat_8_8_128.dat.szp 8192 64 float random\n");
-        exit(0);
-    }
 
-    sprintf(zipFilePath, "%s", argv[1]);
-    nbEle = strtoimax(argv[2], NULL, 10);
-    int blockSize = atoi(argv[3]);
-    char* dataType = argv[4];
-    char* accessType = argv[5];
-    int sz_dataType = SZ_FLOAT;
-    int accessMode = SZP_RANDOMACCESS;
-
-    if (strcmp(dataType, "float") != 0 && strcmp(dataType, "double") != 0)
-    {
-        printf("Error: data type must be 'float' or 'double'!\n");
-        exit(0);
-    }
-    if (strcmp(dataType, "double") == 0)
-    {
-        sz_dataType = SZ_DOUBLE;
-    }
-
-    if (strcmp(accessType, "random") == 0)
-    {
-        accessMode = SZP_RANDOMACCESS;
-    }
-    else if (strcmp(accessType, "nonrandom") == 0)
-    {
-        accessMode = SZP_NONRANDOMACCESS;
-    }
-    else
-    {
-        printf("Error: access type must be 'random' or 'nonrandom'!\n");
-        exit(0);
-    }
-
-    sprintf(outputFilePath, "%s.out", zipFilePath);
-
-    size_t byteLength;
-    int status;
-    unsigned char *bytes = szp_readByteData(zipFilePath, &byteLength, &status);
-    if (status != SZ_SCES)
-    {
-        printf("Error: %s cannot be read!\n", zipFilePath);
-        exit(0);
-    }
-
-    cost_start();
-
-    void *data = szp_decompress(accessMode, sz_dataType, bytes, byteLength, nbEle, blockSize);
-    cost_end();
+// Function to evaluate decompression quality
+BenchmarkResult evaluateQuality(void* ori_data, void* data, size_t nbEle, int sz_dataType, size_t byteLength) {
+    BenchmarkResult result;
+    result.timeCost = totalCost;
     
-    free(bytes);
-    printf("timecost=%f\n", totalCost);
-
-    // Write the decompressed data to the output file
-    if (sz_dataType == SZ_FLOAT)
-    {
-        szp_writeFloatData_inBytes((float*)data, nbEle, outputFilePath, &status);
-    }
-    else // SZ_DOUBLE
-    {
-        szp_writeDoubleData_inBytes((double*)data, nbEle, outputFilePath, &status);
-    }
-
-    if (status != SZ_SCES)
-    {
-        printf("Error: %s cannot be written!\n", outputFilePath);
-        exit(0);
-    }
-    printf("done\n");
-
-    char oriFilePath[645];
-    strcpy(oriFilePath, zipFilePath);
-    oriFilePath[strlen(zipFilePath) - 4] = '\0';
-    
-    void* ori_data = NULL;
-    if (sz_dataType == SZ_FLOAT)
-    {
-        ori_data = szp_readFloatData(oriFilePath, &totalNbEle, &status);
-    }
-    else // SZ_DOUBLE
-    {
-        ori_data = szp_readDoubleData(oriFilePath, &totalNbEle, &status);
-    }
-    
-    if (status != SZ_SCES)
-    {
-        printf("Error: %s cannot be read!\n", oriFilePath);
-        free(data); // Free allocated memory before exiting
-        exit(0);
-    }
-
     if (sz_dataType == SZ_FLOAT)
     {
         float* ori_data_f = (float*)ori_data;
         float* data_f = (float*)data;
         size_t i = 0;
-        double Max = 0, Min = 0, diffMax = 0; // Use double for precision in calculations
+        double Max = 0, Min = 0, diffMax = 0;
 
         if (nbEle > 0) {
             Max = ori_data_f[0];
@@ -191,9 +171,17 @@ int main(int argc, char *argv[])
         double nrmse = (range == 0) ? 0 : sqrt(mse) / range;
         double compressionRatio = 1.0 * nbEle * sizeof(float) / byteLength;
 
+        result.maxAbsErr = diffMax;
+        result.maxRelErr = (range == 0) ? 0 : diffMax / range;
+        result.maxPwRelErr = maxpw_relerr;
+        result.psnr = psnr;
+        result.nrmse = nrmse;
+        result.acEff = acEff;
+        result.compressionRatio = compressionRatio;
+        
         printf("Min=%.20G, Max=%.20G, range=%.20G\n", Min, Max, range);
         printf("Max absolute error = %.10f\n", diffMax);
-        printf("Max relative error = %f\n", (range == 0) ? 0 : diffMax / range);
+        printf("Max relative error = %f\n", result.maxRelErr);
         printf("Max pw relative error = %f\n", maxpw_relerr);
         printf("PSNR = %f, NRMSE= %.20G\n", psnr, nrmse);
         printf("acEff=%f\n", acEff);
@@ -254,16 +242,211 @@ int main(int argc, char *argv[])
         double nrmse = (range == 0) ? 0 : sqrt(mse) / range;
         double compressionRatio = 1.0 * nbEle * sizeof(double) / byteLength;
 
+        result.maxAbsErr = diffMax;
+        result.maxRelErr = (range == 0) ? 0 : diffMax / range;
+        result.maxPwRelErr = maxpw_relerr;
+        result.psnr = psnr;
+        result.nrmse = nrmse;
+        result.acEff = acEff;
+        result.compressionRatio = compressionRatio;
+        
         printf("Min=%.20G, Max=%.20G, range=%.20G\n", Min, Max, range);
         printf("Max absolute error = %.10f\n", diffMax);
-        printf("Max relative error = %f\n", (range == 0) ? 0 : diffMax / range);
+        printf("Max relative error = %f\n", result.maxRelErr);
         printf("Max pw relative error = %f\n", maxpw_relerr);
         printf("PSNR = %f, NRMSE= %.20G\n", psnr, nrmse);
         printf("acEff=%f\n", acEff);
         printf("compressionRatio = %f\n", compressionRatio);
     }
+    
+    return result;
+}
 
-    free(data);
+void printUsage() {
+    printf("Usage: testfloat_decompress_fastmode1 [srcFilePath] [nbEle] [block size] [data_type] [access_type] [repetitions] [warmup_runs] [output_csv]\n");
+    printf("Example: testfloat_decompress_fastmode1 testfloat_8_8_128.dat.szp 8192 64 float random 10 2 results.csv\n");
+    printf("  - repetitions, warmup_runs, and output_csv are optional\n");
+}
+
+int main(int argc, char *argv[])
+{
+    size_t nbEle, totalNbEle;
+    char zipFilePath[640], outputFilePath[645], csvFilePath[650] = {0};
+    
+    if (argc < 6)
+    {
+        printUsage();
+        exit(0);
+    }
+
+    sprintf(zipFilePath, "%s", argv[1]);
+    nbEle = strtoimax(argv[2], NULL, 10);
+    int blockSize = atoi(argv[3]);
+    char* dataType = argv[4];
+    char* accessType = argv[5];
+    
+    // Benchmark parameters - default values
+    int repetitions = 1;
+    int warmupRuns = 0;
+    
+    // Parse optional benchmark parameters
+    if (argc >= 7) repetitions = atoi(argv[6]);
+    if (argc >= 8) warmupRuns = atoi(argv[7]);
+    if (argc >= 9) sprintf(csvFilePath, "%s", argv[8]);
+    
+    int sz_dataType = SZ_FLOAT;
+    int accessMode = SZP_RANDOMACCESS;
+
+    if (strcmp(dataType, "float") != 0 && strcmp(dataType, "double") != 0)
+    {
+        printf("Error: data type must be 'float' or 'double'!\n");
+        exit(0);
+    }
+    if (strcmp(dataType, "double") == 0)
+    {
+        sz_dataType = SZ_DOUBLE;
+    }
+
+    if (strcmp(accessType, "random") == 0)
+    {
+        accessMode = SZP_RANDOMACCESS;
+    }
+    else if (strcmp(accessType, "nonrandom") == 0)
+    {
+        accessMode = SZP_NONRANDOMACCESS;
+    }
+    else
+    {
+        printf("Error: access type must be 'random' or 'nonrandom'!\n");
+        exit(0);
+    }
+
+    // Print benchmark configuration
+    printf("SZp Decompression Benchmark Configuration\n");
+    printf("=========================================\n");
+    printf("Compressed file: %s\n", zipFilePath);
+    printf("Data elements: %zu\n", nbEle);
+    printf("Block size: %d\n", blockSize);
+    printf("Data type: %s\n", dataType);
+    printf("Access type: %s\n", accessType);
+    printf("Repetitions: %d\n", repetitions);
+    printf("Warmup runs: %d\n", warmupRuns);
+    if (csvFilePath[0]) printf("CSV output: %s\n", csvFilePath);
+    printf("=========================================\n\n");
+
+    sprintf(outputFilePath, "%s.out", zipFilePath);
+
+    // Read compressed data only once
+    size_t byteLength;
+    int status;
+    printf("Reading compressed file...\n");
+    unsigned char *bytes = szp_readByteData(zipFilePath, &byteLength, &status);
+    if (status != SZ_SCES)
+    {
+        printf("Error: %s cannot be read!\n", zipFilePath);
+        exit(0);
+    }
+
+    // Read original data for quality evaluation
+    char oriFilePath[645];
+    strcpy(oriFilePath, zipFilePath);
+    oriFilePath[strlen(zipFilePath) - 4] = '\0';
+    
+    printf("Reading original file for comparison...\n");
+    void* ori_data = NULL;
+    if (sz_dataType == SZ_FLOAT)
+    {
+        ori_data = szp_readFloatData(oriFilePath, &totalNbEle, &status);
+    }
+    else // SZ_DOUBLE
+    {
+        ori_data = szp_readDoubleData(oriFilePath, &totalNbEle, &status);
+    }
+    
+    if (status != SZ_SCES)
+    {
+        printf("Error: %s cannot be read!\n", oriFilePath);
+        free(bytes);
+        exit(0);
+    }
+
+    if (nbEle > totalNbEle) {
+        printf("Warning: Specified element count (%zu) exceeds file size (%zu). Using file size.\n", 
+               nbEle, totalNbEle);
+        nbEle = totalNbEle;
+    }
+
+    // Vector to store benchmark results (excluding warmup runs)
+    std::vector<BenchmarkResult> results;
+
+    // Perform warmup runs (results not recorded)
+    if (warmupRuns > 0) {
+        printf("\nPerforming %d warmup runs...\n", warmupRuns);
+        for (int i = 0; i < warmupRuns; i++) {
+            printf("  Warmup run %d of %d: ", i+1, warmupRuns);
+            
+            cost_start();
+            void *data = szp_decompress(accessMode, sz_dataType, bytes, byteLength, nbEle, blockSize);
+            cost_end();
+            
+            printf("time=%f\n", totalCost);
+            free(data);
+        }
+    }
+
+    // Perform actual benchmark runs
+    printf("\nStarting %d benchmark runs...\n", repetitions);
+    for (int i = 0; i < repetitions; i++) {
+        printf("\nRun %d of %d:\n", i+1, repetitions);
+        
+        cost_start();
+        void *data = szp_decompress(accessMode, sz_dataType, bytes, byteLength, nbEle, blockSize);
+        cost_end();
+        
+        printf("timecost=%f\n", totalCost);
+        
+        // Evaluate decompression quality
+        BenchmarkResult result = evaluateQuality(ori_data, data, nbEle, sz_dataType, byteLength);
+        result.timeCost = totalCost;  // Set the measured time
+        
+        // Save result
+        results.push_back(result);
+        
+        // Write decompressed data to file only on the last run
+        if (i == repetitions - 1) {
+            printf("  Writing decompressed data to %s\n", outputFilePath);
+            if (sz_dataType == SZ_FLOAT)
+            {
+                szp_writeFloatData_inBytes((float*)data, nbEle, outputFilePath, &status);
+            }
+            else // SZ_DOUBLE
+            {
+                szp_writeDoubleData_inBytes((double*)data, nbEle, outputFilePath, &status);
+            }
+
+            if (status != SZ_SCES)
+            {
+                printf("Error: %s cannot be written!\n", outputFilePath);
+            }
+        }
+        
+        free(data);
+    }
+
+    // Calculate and print statistics
+    if (results.size() > 1) {
+        calculateStats(results);
+    }
+    
+    // Write to CSV if requested
+    if (csvFilePath[0]) {
+        writeToCsv(csvFilePath, results);
+        printf("Results written to CSV: %s\n", csvFilePath);
+    }
+
+    printf("\nBenchmark completed.\n");
+    free(bytes);
     free(ori_data);
+
     return 0;
 }


### PR DESCRIPTION
This pull request brings improvement to existing testing example, and a new test example that can better manager the multi-dim dataset benchmark, supporting dataset statistics analysis, warmup/repetition setting.

========= BELOW CONTENT IS GENERATED BY COPILOT TO PROVIDE SUMMARY ========= 

This pull request introduces a new multi-dimensional compression benchmark tool and significantly improves the benchmarking capabilities of the existing `testfloat_compress_fastmode1` tool. It also makes minor code optimizations and updates to the build system to support the new benchmark. The main changes are grouped below:

### Benchmarking and Tooling Improvements

* Added a new tool, `test_multidim`, for benchmarking compression and decompression of multi-dimensional datasets. This tool supports both compress and decompress modes, provides performance and accuracy statistics, writes results to CSV, and supports warmup and repeated runs for robust benchmarking. (`example/test_multidim.cc`)
* Enhanced `testfloat_compress_fastmode1` to support multiple repetitions, warmup runs, and CSV output for benchmarking results. The tool now calculates and prints detailed statistics (average, min, max, standard deviation) for time and compression ratio, and only writes compressed data on the final run. (`example/testfloat_compress_fastmode1.cc`) [[1]](diffhunk://#diff-dd49e8978448d97bbb52dcd7db14b54b35f0e3310a9461cc1ab5afe2df37513aL2-R90) [[2]](diffhunk://#diff-dd49e8978448d97bbb52dcd7db14b54b35f0e3310a9461cc1ab5afe2df37513aR106-R117) [[3]](diffhunk://#diff-dd49e8978448d97bbb52dcd7db14b54b35f0e3310a9461cc1ab5afe2df37513aR126-R135) [[4]](diffhunk://#diff-dd49e8978448d97bbb52dcd7db14b54b35f0e3310a9461cc1ab5afe2df37513aR165-R182) [[5]](diffhunk://#diff-dd49e8978448d97bbb52dcd7db14b54b35f0e3310a9461cc1ab5afe2df37513aR196-R265)

### Build System Updates

* Updated `example/Makefile.am` to build the new `test_multidim` tool and link it with the SZp library. (`example/Makefile.am`)

### Code Optimization

* Removed the use of the deprecated `register` keyword from two functions in `SZp/src/szp_TypeManager.cc` for modern C++ compatibility. (`SZp/src/szp_TypeManager.cc`) [[1]](diffhunk://#diff-e6b8ec05d161f285bfa2d44bfdeeafd6f7d04369a753d4b5b7a1ecdb8aab4b6dL150-R150) [[2]](diffhunk://#diff-e6b8ec05d161f285bfa2d44bfdeeafd6f7d04369a753d4b5b7a1ecdb8aab4b6dL1003-R1003)